### PR TITLE
feat: make public by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@flatfile/sdk",
   "version": "1.0.0-beta.0",
   "description": "Flatfile SDK",
+  "private": false,
   "repository": {
     "type": "git",
     "url": "git+https://github.com/FlatFilers/sdk.git"


### PR DESCRIPTION
allows `npm publish` to run without having to specify public access