### PR TITLE
feat(sdk): Added UnauthorizationError descriptions;

### DIFF
--- a/src/errors/UnauthorizedError.ts
+++ b/src/errors/UnauthorizedError.ts
@@ -7,4 +7,12 @@ export class UnauthorizedError extends FlatfileError {
     'The JWT was not signed with a recognized private key or you did not provide the ' +
     'necessary information to identify the end user'
   public userMessage = 'There was an issue establishing a secure import session.'
+
+  constructor(debug?: string, code?: string) {
+    super(debug)
+    if (debug) {
+      this.debug = debug
+    }
+    this.code = code ?? 'FF-UA-00'
+  }
 }

--- a/src/graphql/ApiService.ts
+++ b/src/graphql/ApiService.ts
@@ -231,7 +231,13 @@ export class ApiService {
   public handleGraphQLErrors(errors?: GraphQLError[], message?: string): void {
     if (errors?.length) {
       errors.forEach((e) => {
-        if (e.message === 'Unauthorized') {
+        if (
+          e.extensions?.response?.statusCode === 401 &&
+          typeof e.extensions.response.error === 'string'
+        ) {
+          const { error: debug, message: code } = e.extensions.response
+          throw new UnauthorizedError(debug, code)
+        } else if (e.message === 'Unauthorized') {
           throw new UnauthorizedError()
         }
 


### PR DESCRIPTION
Added new Unauthorization error descriptions:

- `FF-UA-00` - generic auth error
- `FF-UA-01` - The embed ID was not provided as a value for the `embed` property in JWT.
- `FF-UA-02` - The embed ID provided as a value for the `embed` property is invalid. Make sure it contains a valid UUID.
- `FF-UA-03` - The embed does not exist.
- `FF-UA-04` - The embed does not have an active private key. Please reset your private key using Flatfile Dashboard.
- `FF-UA-05` Your request was in developer mode, but used a known production embed ID. Please make sure you implement "Securing Data" part before using production embed.

All of the error codes & descriptions are coming from the FF API.