### PR TITLE
chore: correct url for onprem

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flatfile/sdk",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Flatfile SDK",
   "private": false,
   "repository": {

--- a/src/importer/index.ts
+++ b/src/importer/index.ts
@@ -27,7 +27,7 @@ export function flatfileImporter(
     }
 
     const o = document.createElement('iframe')
-    o.src = `${config.mountUrl || process.env.MOUNT_URL}/e?jwt=${encodeURI(api.token)}${
+    o.src = `${config.mountUrl || process.env.MOUNT_URL}/e/?jwt=${encodeURI(api.token)}${
       batchId ? `&batchId=${batchId}` : ''
     }`
 


### PR DESCRIPTION
Updates the embed URL to `/e/` instead of `/e?`