### PR TITLE
fix(sdk): adding fallback request to batch subscription

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@flatfile/sdk",
-  "version": "2.0.0",
+  "version": "2.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@flatfile/sdk",
-      "version": "2.0.0",
+      "version": "2.0.2",
       "license": "ISC",
       "dependencies": {
         "eventemitter3": "^4.0.7",

--- a/src/graphql/ApiService.spec.ts
+++ b/src/graphql/ApiService.spec.ts
@@ -8,6 +8,16 @@ import { mockGraphQLRequest } from '../lib/test-helper'
 import { ERecordStatus } from '../service/FlatfileRecord'
 import { ApiService } from './ApiService'
 
+jest.mock('../utils/handlePollFallback', () => {
+  return {
+    ...jest.requireActual('../utils/handlePollFallback'),
+
+    WAIT_TIME_BEFORE_START_POLLING: 0,
+
+    POLLING_INTERVAL: 0,
+  }
+})
+
 describe('ApiService', () => {
   let session: ImportSession
   let api: ApiService
@@ -123,6 +133,71 @@ describe('ApiService', () => {
     test('handles errors', async () => {
       mockError()
       await expect(req()).rejects.toThrow(RequestError)
+    })
+  })
+
+  describe('getBatch', () => {
+    const req = () => api.getBatch('batchId')
+
+    test('resolves successfully', async () => {
+      const payload = {
+        status: 'success',
+        id: 'batchId',
+      }
+      mockGraphQLRequest('getBatch', 200, payload)
+      const res = await req()
+      await expect(res.status).toEqual('success')
+    })
+
+    test('handles errors', async () => {
+      mockError()
+      await expect(req()).rejects.toThrow(RequestError)
+    })
+  })
+
+  describe('getBatch', () => {
+    const req = () => api.getBatch('batchId')
+
+    test('resolves successfully', async () => {
+      const payload = {
+        status: 'success',
+        id: 'batchId',
+      }
+      mockGraphQLRequest('getBatch', 200, payload)
+      const res = await req()
+      await expect(res.status).toEqual('success')
+    })
+
+    test('handles errors', async () => {
+      mockError()
+      await expect(req()).rejects.toThrow(RequestError)
+    })
+  })
+
+  describe('fallbackGetBatchSubscription', () => {
+    test.each(['submitted', 'cancelled', 'evaluate'])(
+      'should get batch on execute fallback',
+      async (status) => {
+        const payload = {
+          status: status,
+          id: 'batchId',
+        }
+        mockGraphQLRequest('getBatch', 200, payload)
+        const result = await api.fallbackGetBatchSubscription('batchId')
+
+        expect(result).toEqual(payload)
+      }
+    )
+
+    test('should get null', async () => {
+      const payload = {
+        status: 'invalid',
+        id: 'batchId',
+      }
+      mockGraphQLRequest('getBatch', 200, payload)
+
+      const result = await api.fallbackGetBatchSubscription('batchId')
+      expect(result).toBeNull()
     })
   })
 

--- a/src/graphql/ApiService.spec.ts
+++ b/src/graphql/ApiService.spec.ts
@@ -155,25 +155,6 @@ describe('ApiService', () => {
     })
   })
 
-  describe('getBatch', () => {
-    const req = () => api.getBatch('batchId')
-
-    test('resolves successfully', async () => {
-      const payload = {
-        status: 'success',
-        id: 'batchId',
-      }
-      mockGraphQLRequest('getBatch', 200, payload)
-      const res = await req()
-      await expect(res.status).toEqual('success')
-    })
-
-    test('handles errors', async () => {
-      mockError()
-      await expect(req()).rejects.toThrow(RequestError)
-    })
-  })
-
   describe('fallbackGetBatchSubscription', () => {
     test.each(['submitted', 'cancelled', 'evaluate'])(
       'should get batch on execute fallback',

--- a/src/graphql/ApiService.ts
+++ b/src/graphql/ApiService.ts
@@ -42,7 +42,7 @@ export class ApiService {
         Authorization: `Bearer ${this.token}`,
       },
     })
-    this.pubsub = new SubscriptionClient(`${apiUrl.replace(/^http/, 'ws')}/graphql1`, {
+    this.pubsub = new SubscriptionClient(`${apiUrl.replace(/^http/, 'ws')}/graphql`, {
       reconnect: true,
       lazy: true,
       connectionParams: {

--- a/src/graphql/ApiService.ts
+++ b/src/graphql/ApiService.ts
@@ -1,18 +1,21 @@
 import { ClientError, GraphQLClient } from 'graphql-request'
 import { GraphQLError } from 'graphql-request/dist/types'
 import { SubscriptionClient } from 'graphql-subscriptions-client'
+import { IBatch } from 'old/graphql/subscriptions/BATCH_STATUS_UPDATED'
 
 import { FlatfileError } from '../errors/FlatfileError'
 import { RequestError } from '../errors/RequestError'
 import { UnauthorizedError } from '../errors/UnauthorizedError'
 import { IImportMeta, ImportSession } from '../importer/ImportSession'
 import { ERecordStatus, TPrimitive } from '../service/FlatfileRecord'
+import { handlePollFallback } from '../utils/handlePollFallback'
 import {
   INITIALIZE_EMPTY_BATCH,
   InitializeEmptyBatchPayload,
   InitializeEmptyBatchResponse,
 } from './mutations/INITIALIZE_EMPTY_BATCH'
 import { UPDATE_WORKSPACE_ENV } from './mutations/UPDATE_WORKSPACE_ENV'
+import { GET_BATCH } from './queries/GET_BATCH'
 import {
   GET_FINAL_DATABASE_VIEW,
   GetFinalDatabaseViewPayload,
@@ -198,19 +201,50 @@ export class ApiService {
   }
 
   /**
+   * Get batch
+   *
+   * @param batchId
+   */
+  async getBatch(batchId: string): Promise<{ id: string; status: string }> {
+    const req = this.client.request(GET_BATCH, {
+      batchId,
+    })
+
+    return this.handleResponse('getBatch', req)
+  }
+
+  /**
+   * get batch and check status for subscription fail fallback
+   *
+   * @param batchId
+   */
+  fallbackGetBatchSubscription = async (batchId: string): Promise<IBatch | null> => {
+    const result = await this.getBatch(batchId)
+    if (['submitted', 'cancelled', 'evaluate'].includes(result?.status)) {
+      return result
+    }
+    return null
+  }
+
+  /**
    * Start a websocket subscription for a specific batchID
    *
    * @param batchId
    * @param observe
    */
   /* istanbul ignore next */
-  public subscribeBatchStatusUpdated(batchId: string, observe: (status: string) => void): void {
+  public async subscribeBatchStatusUpdated(
+    batchId: string,
+    observe: (batch: IBatch) => void
+  ): Promise<void> {
+    handlePollFallback(() => this.fallbackGetBatchSubscription(batchId), observe)
+
     const query = BATCH_STATUS_UPDATED
     this.pubsub.request({ query, variables: { batchId } }).subscribe({
       next: ({ data, errors }: IBatchStatusSubscription) => {
         const batch = data?.batchStatusUpdated
         if (errors) this.handleGraphQLErrors(errors)
-        else if (batch?.id) observe(batch?.status)
+        else if (batch?.id) observe(batch)
       },
     })
   }

--- a/src/graphql/ApiService.ts
+++ b/src/graphql/ApiService.ts
@@ -42,7 +42,7 @@ export class ApiService {
         Authorization: `Bearer ${this.token}`,
       },
     })
-    this.pubsub = new SubscriptionClient(`${apiUrl.replace(/^http/, 'ws')}/graphql`, {
+    this.pubsub = new SubscriptionClient(`${apiUrl.replace(/^http/, 'ws')}/graphql1`, {
       reconnect: true,
       lazy: true,
       connectionParams: {

--- a/src/graphql/ApiService.ts
+++ b/src/graphql/ApiService.ts
@@ -220,7 +220,7 @@ export class ApiService {
    */
   fallbackGetBatchSubscription = async (batchId: string): Promise<IBatch | null> => {
     const result = await this.getBatch(batchId)
-    if (['submitted', 'cancelled', 'evaluate'].includes(result?.status)) {
+    if (['submitted', 'cancelled', 'evaluate'].includes(result.status)) {
       return result
     }
     return null

--- a/src/graphql/queries/GET_BATCH.ts
+++ b/src/graphql/queries/GET_BATCH.ts
@@ -1,0 +1,10 @@
+import { gql } from 'graphql-request'
+
+export const GET_BATCH = gql`
+  query GetBatch($batchId: UUID!) {
+    getBatch(batchId: $batchId) {
+      id
+      status
+    }
+  }
+`

--- a/src/importer/ImportSession.spec.ts
+++ b/src/importer/ImportSession.spec.ts
@@ -2,6 +2,7 @@ import { Flatfile } from '../Flatfile'
 import { ApiService } from '../graphql/ApiService'
 import { IteratorCallback, RecordChunkIterator } from '../lib/RecordChunkIterator'
 import { makeRows } from '../lib/test-helper'
+import { IBatch } from '../old/graphql/subscriptions/BATCH_STATUS_UPDATED'
 import { ImportFrame } from './ImportFrame'
 import { ImportSession } from './ImportSession'
 
@@ -46,6 +47,59 @@ describe('ImportSession', () => {
       const firstFrame = session.iframe
       expect(firstFrame).toBeInstanceOf(ImportFrame)
       expect(session.iframe).toBe(firstFrame)
+    })
+  })
+
+  describe('init', () => {
+    test('should emit evaluate on batch subscription after init', async () => {
+      const spy = jest.spyOn(session, 'emit')
+      jest
+        .spyOn(flatfile.api as ApiService, 'subscribeBatchStatusUpdated')
+        .mockImplementation((batchId: string, method: (batch: IBatch) => void) =>
+          Promise.resolve(method({ id: batchId, status: 'evaluate' }))
+        )
+
+      session.init()
+
+      expect(spy).toHaveBeenNthCalledWith(
+        1,
+        'evaluate',
+        expect.objectContaining({
+          workbookId: 'hij',
+        })
+      )
+    })
+
+    test('should emit complete on batch subscription after and batch was submitted', async () => {
+      const spy = jest.spyOn(session, 'emit')
+      jest
+        .spyOn(flatfile.api as ApiService, 'subscribeBatchStatusUpdated')
+        .mockImplementation((batchId: string, method: (batch: IBatch) => void) =>
+          Promise.resolve(method({ id: batchId, status: 'submitted' }))
+        )
+
+      session.init()
+
+      expect(spy).toHaveBeenNthCalledWith(
+        2,
+        'complete',
+        expect.objectContaining({
+          batchId: 'abc',
+        })
+      )
+    })
+
+    test('should init if batch got cancelled', async () => {
+      const spy = jest.spyOn(flatfile.api as ApiService, 'init')
+      jest
+        .spyOn(flatfile.api as ApiService, 'subscribeBatchStatusUpdated')
+        .mockImplementation((batchId: string, method: (batch: IBatch) => void) =>
+          Promise.resolve(method({ id: batchId, status: 'cancelled' }))
+        )
+
+      session.init()
+
+      expect(spy).toHaveBeenCalled()
     })
   })
 

--- a/src/importer/ImportSession.spec.ts
+++ b/src/importer/ImportSession.spec.ts
@@ -51,14 +51,16 @@ describe('ImportSession', () => {
   })
 
   describe('init', () => {
-    test('should emit evaluate on batch subscription after init', async () => {
-      const spy = jest.spyOn(session, 'emit')
+    const spy = jest.spyOn(session, 'emit')
+    const mockSubscription = (status: string) =>
       jest
         .spyOn(flatfile.api as ApiService, 'subscribeBatchStatusUpdated')
         .mockImplementation((batchId: string, method: (batch: IBatch) => void) =>
-          Promise.resolve(method({ id: batchId, status: 'evaluate' }))
+          Promise.resolve(method({ id: batchId, status }))
         )
 
+    test('should emit evaluate on batch subscription after init', async () => {
+      mockSubscription('evaluate')
       session.init()
 
       expect(spy).toHaveBeenNthCalledWith(
@@ -71,13 +73,7 @@ describe('ImportSession', () => {
     })
 
     test('should emit complete on batch subscription after and batch was submitted', async () => {
-      const spy = jest.spyOn(session, 'emit')
-      jest
-        .spyOn(flatfile.api as ApiService, 'subscribeBatchStatusUpdated')
-        .mockImplementation((batchId: string, method: (batch: IBatch) => void) =>
-          Promise.resolve(method({ id: batchId, status: 'submitted' }))
-        )
-
+      mockSubscription('submitted')
       session.init()
 
       expect(spy).toHaveBeenNthCalledWith(
@@ -90,12 +86,7 @@ describe('ImportSession', () => {
     })
 
     test('should init if batch got cancelled', async () => {
-      const spy = jest.spyOn(flatfile.api as ApiService, 'init')
-      jest
-        .spyOn(flatfile.api as ApiService, 'subscribeBatchStatusUpdated')
-        .mockImplementation((batchId: string, method: (batch: IBatch) => void) =>
-          Promise.resolve(method({ id: batchId, status: 'cancelled' }))
-        )
+      mockSubscription('cancelled')
 
       session.init()
 

--- a/src/importer/ImportSession.spec.ts
+++ b/src/importer/ImportSession.spec.ts
@@ -51,7 +51,6 @@ describe('ImportSession', () => {
   })
 
   describe('init', () => {
-    const spy = jest.spyOn(session, 'emit')
     const mockSubscription = (status: string) =>
       jest
         .spyOn(flatfile.api as ApiService, 'subscribeBatchStatusUpdated')
@@ -60,6 +59,8 @@ describe('ImportSession', () => {
         )
 
     test('should emit evaluate on batch subscription after init', async () => {
+      const spy = jest.spyOn(session, 'emit')
+
       mockSubscription('evaluate')
       session.init()
 
@@ -73,6 +74,7 @@ describe('ImportSession', () => {
     })
 
     test('should emit complete on batch subscription after and batch was submitted', async () => {
+      const spy = jest.spyOn(session, 'emit')
       mockSubscription('submitted')
       session.init()
 
@@ -87,6 +89,7 @@ describe('ImportSession', () => {
 
     test('should init if batch got cancelled', async () => {
       mockSubscription('cancelled')
+      const spy = jest.spyOn(session, 'emit')
 
       session.init()
 

--- a/src/importer/ImportSession.ts
+++ b/src/importer/ImportSession.ts
@@ -105,13 +105,13 @@ export class ImportSession extends TypedEventManager<IImportSessionEvents> {
     return chunkIterator
   }
 
-  private subscribeToBatchStatus(): void {
-    return this.api.subscribeBatchStatusUpdated(this.batchId, async (status) => {
-      if (status === 'evaluate') {
+  private async subscribeToBatchStatus(): Promise<void> {
+    return await this.api.subscribeBatchStatusUpdated(this.batchId, async (batch) => {
+      if (batch.status === 'evaluate') {
         this.emit('evaluate', this)
       }
 
-      if (status === 'submitted') {
+      if (batch.status === 'submitted') {
         this.emit('submit', this)
         this.emit('complete', {
           batchId: this.batchId,
@@ -119,7 +119,7 @@ export class ImportSession extends TypedEventManager<IImportSessionEvents> {
         })
       }
 
-      if (status === 'cancelled') {
+      if (batch.status === 'cancelled') {
         const meta = await this.api.init()
         this.meta = { ...this.meta, ...meta }
         this.init()

--- a/src/old/graphql/subscriptions/BATCH_STATUS_UPDATED.ts
+++ b/src/old/graphql/subscriptions/BATCH_STATUS_UPDATED.ts
@@ -1,10 +1,12 @@
 import { gql } from 'graphql-request'
 
+export interface IBatch {
+  id: string
+  status: string
+}
+
 export interface BatchStatusUpdatedResponse {
-  batchStatusUpdated: {
-    id: string
-    status: string
-  }
+  batchStatusUpdated: IBatch
 }
 
 export const BATCH_STATUS_UPDATED = gql`

--- a/src/utils/handlePollFallback.spec.ts
+++ b/src/utils/handlePollFallback.spec.ts
@@ -1,0 +1,29 @@
+import { handlePollFallback } from './handlePollFallback'
+
+const wait = async (time = 0) => await new Promise((resolve) => setTimeout(resolve, time))
+
+describe('handlePollFallback', () => {
+  test('should execute poll method and callback', async () => {
+    const fallbackMethod = jest.fn().mockResolvedValue(Promise.resolve(true))
+    const callback = jest.fn()
+
+    handlePollFallback(fallbackMethod, callback, 0, 0)
+
+    await wait(100)
+
+    expect(fallbackMethod).toHaveBeenCalled()
+    expect(callback).toHaveBeenCalledWith(true)
+  })
+
+  test('should execute poll method, but not callback', async () => {
+    const fallbackMethod = jest.fn().mockResolvedValue(Promise.resolve(false))
+    const callback = jest.fn()
+
+    handlePollFallback(fallbackMethod, callback, 0, 0)
+
+    await wait(100)
+
+    expect(fallbackMethod).toHaveBeenCalled()
+    expect(callback).not.toHaveBeenCalled()
+  })
+})

--- a/src/utils/handlePollFallback.ts
+++ b/src/utils/handlePollFallback.ts
@@ -1,5 +1,5 @@
-export const WAIT_TIME_BEFORE_START_POLLING = 20 * 1000
-export const POLLING_INTERVAL = 10 * 1000
+export const WAIT_TIME_BEFORE_START_POLLING = 5 * 1000
+export const POLLING_INTERVAL = 1 * 1000
 
 export const handlePollFallback = (
   fallbackMethod: () => Promise<any | null>,

--- a/src/utils/handlePollFallback.ts
+++ b/src/utils/handlePollFallback.ts
@@ -1,0 +1,28 @@
+export const WAIT_TIME_BEFORE_START_POLLING = 20 * 1000
+export const POLLING_INTERVAL = 10 * 1000
+
+export const handlePollFallback = (
+  fallbackMethod: () => Promise<any | null>,
+  cb: (param: any) => void,
+  waitTimeBeforeStartPoll = WAIT_TIME_BEFORE_START_POLLING,
+  pollingInterval = POLLING_INTERVAL
+): void => {
+  let idInterval: NodeJS.Timeout
+
+  const idTimeout: NodeJS.Timeout = setTimeout(() => {
+    clearInterval(idInterval)
+    idInterval = setInterval(async () => {
+      const result = await fallbackMethod()
+
+      if (result) {
+        cb(result)
+        clearTimers()
+      }
+    }, pollingInterval)
+  }, waitTimeBeforeStartPoll)
+
+  const clearTimers = () => {
+    clearTimeout(idTimeout)
+    clearInterval(idInterval)
+  }
+}


### PR DESCRIPTION
Currently, the user gets stuck on the upload process when the API fails in the WSS connection, this PR adds a poll fallback to the batch subscription

PUB SUB ENABLED
https://user-images.githubusercontent.com/101140723/194909481-ad996def-56ec-4eb9-9c3d-51cc72f1d124.mov

PUB SUB DISABLED
https://user-images.githubusercontent.com/101140723/194911067-15236eeb-61e0-4893-b2fb-c21b55f990d9.mov

