### PR TITLE
feat(sdk): poll until batch submitted or cancelled

### DIFF
--- a/src/Flatfile.spec.ts
+++ b/src/Flatfile.spec.ts
@@ -3,7 +3,8 @@ import { ImplementationError } from './errors/ImplementationError'
 import { Flatfile } from './Flatfile'
 import { ApiService } from './graphql/ApiService'
 import { ImportSession } from './importer/ImportSession'
-import { RecordChunkIterator } from './lib/RecordChunkIterator'
+import { IteratorCallback, RecordChunkIterator } from './lib/RecordChunkIterator'
+import { RecordsChunk } from './service/RecordsChunk'
 import { UIService } from './service/UIService'
 import { IFlatfileImporterConfig } from './types'
 
@@ -173,6 +174,12 @@ describe('Flatfile', () => {
       })
 
       test('should call processing pending records on evaluate', async () => {
+        jest
+          .spyOn(ImportSession.prototype, 'processPendingRecords')
+          .mockImplementation((fn: IteratorCallback) => {
+            fn({ records: [{ data: true }] } as unknown as RecordsChunk, jest.fn())
+            return Promise.resolve({} as RecordChunkIterator)
+          })
         const importSessionConfig = {
           chunkSize: 10,
           onData: jest.fn(),
@@ -185,6 +192,7 @@ describe('Flatfile', () => {
           expect.any(Function),
           { chunkSize: 10 }
         )
+        expect(importSessionConfig.onData).toHaveBeenCalled()
       })
 
       test('should call on-complete event handler on submit', async () => {

--- a/src/Flatfile.spec.ts
+++ b/src/Flatfile.spec.ts
@@ -182,7 +182,7 @@ describe('Flatfile', () => {
         await new Promise(process.nextTick)
 
         expect(ImportSession.prototype.processPendingRecords).toHaveBeenCalledWith(
-          importSessionConfig.onData,
+          expect.any(Function),
           { chunkSize: 10 }
         )
       })

--- a/src/Flatfile.ts
+++ b/src/Flatfile.ts
@@ -122,10 +122,17 @@ export class Flatfile extends TypedEventManager<IEvents> {
 
       if (onData) {
         session.on('evaluate', async () => {
-          await session.processPendingRecords(onData, {
-            chunkSize,
-            chunkTimeout,
-          })
+          await session.processPendingRecords(
+            (data, next) => {
+              if (data.records.length) {
+                onData(data, next)
+              }
+            },
+            {
+              chunkSize,
+              chunkTimeout,
+            }
+          )
         })
       }
 

--- a/src/graphql/ApiService.spec.ts
+++ b/src/graphql/ApiService.spec.ts
@@ -166,7 +166,10 @@ describe('ApiService', () => {
         mockGraphQLRequest('getBatch', 200, payload)
         const result = await api.fallbackGetBatchSubscription('batchId')
 
-        expect(result).toEqual(payload)
+        expect(result).toEqual({
+          result: payload,
+          stopPoll: ['submitted', 'cancelled'].includes(status),
+        })
       }
     )
 

--- a/src/graphql/ApiService.ts
+++ b/src/graphql/ApiService.ts
@@ -218,10 +218,12 @@ export class ApiService {
    *
    * @param batchId
    */
-  fallbackGetBatchSubscription = async (batchId: string): Promise<IBatch | null> => {
+  fallbackGetBatchSubscription = async (
+    batchId: string
+  ): Promise<{ result: IBatch; stopPoll: boolean } | null> => {
     const result = await this.getBatch(batchId)
     if (['submitted', 'cancelled', 'evaluate'].includes(result.status)) {
-      return result
+      return { result, stopPoll: ['submitted', 'cancelled'].includes(result.status) }
     }
     return null
   }

--- a/src/utils/handlePollFallback.spec.ts
+++ b/src/utils/handlePollFallback.spec.ts
@@ -4,7 +4,9 @@ const wait = async (time = 0) => await new Promise((resolve) => setTimeout(resol
 
 describe('handlePollFallback', () => {
   test('should execute poll method and callback', async () => {
-    const fallbackMethod = jest.fn().mockResolvedValue(Promise.resolve({ result: true }))
+    const fallbackMethod = jest
+      .fn()
+      .mockResolvedValue(Promise.resolve({ result: true, stopPoll: true }))
     const callback = jest.fn()
 
     handlePollFallback(fallbackMethod, callback, 0, 0)

--- a/src/utils/handlePollFallback.spec.ts
+++ b/src/utils/handlePollFallback.spec.ts
@@ -4,7 +4,7 @@ const wait = async (time = 0) => await new Promise((resolve) => setTimeout(resol
 
 describe('handlePollFallback', () => {
   test('should execute poll method and callback', async () => {
-    const fallbackMethod = jest.fn().mockResolvedValue(Promise.resolve(true))
+    const fallbackMethod = jest.fn().mockResolvedValue(Promise.resolve({ result: true }))
     const callback = jest.fn()
 
     handlePollFallback(fallbackMethod, callback, 0, 0)

--- a/src/utils/handlePollFallback.ts
+++ b/src/utils/handlePollFallback.ts
@@ -12,10 +12,13 @@ export const handlePollFallback = (
   const idTimeout: NodeJS.Timeout = setTimeout(() => {
     clearInterval(idInterval)
     idInterval = setInterval(async () => {
-      const result = await fallbackMethod()
+      const data = await fallbackMethod()
 
-      if (result) {
-        cb(result)
+      if (data?.result) {
+        cb(data.result)
+      }
+
+      if (data?.stopPoll) {
         clearTimers()
       }
     }, pollingInterval)


### PR DESCRIPTION
Currently, when the customer doesn't have websocket env, the poll fallback polls the data but stops polling after getting the result. this makes the user get stuck since it will not know when the batch was succeeded or canceled (so the dialog can be closed).

This code is to make it keep polling until the batch gets succeeds or is canceled, and also emits when the batch is in evaluating status. 