### PR TITLE
fix: use the index for the skip

### DIFF
--- a/src/service/RecordsChunk.ts
+++ b/src/service/RecordsChunk.ts
@@ -17,7 +17,7 @@ export class RecordsChunk {
    */
   public async getNextChunk(): Promise<RecordsChunk | null> {
     const { index, limit, status } = this.meta ?? {}
-    const response = await this.session.api.getRecordsByStatus(this.session, status, 0, limit)
+    const response = await this.session.api.getRecordsByStatus(this.session, status, index, limit)
     const { rows = [], totalRows } = response ?? {}
 
     if (response?.totalRows < 1) {


### PR DESCRIPTION
* corrects an issue in which `getNextChunk` always has a skip of 0
* uses the index instead to respect pagination