### PR TITLE
fix: skip exceeds remaining records

### DIFF
--- a/src/service/RecordsChunk.ts
+++ b/src/service/RecordsChunk.ts
@@ -16,8 +16,13 @@ export class RecordsChunk {
    * Get the next chunk of data based on the current chunk
    */
   public async getNextChunk(): Promise<RecordsChunk | null> {
-    const { index, limit, status } = this.meta ?? {}
-    const response = await this.session.api.getRecordsByStatus(this.session, status, index, limit)
+    const { index, limit, status, totalRecords } = this.meta ?? {}
+    let { skip } = this.meta ?? {}
+    if (skip >= totalRecords) {
+      // totalRecords is actually total remaining records
+      skip = 0
+    }
+    const response = await this.session.api.getRecordsByStatus(this.session, status, skip, limit)
     const { rows = [], totalRows } = response ?? {}
 
     if (response?.totalRows < 1) {
@@ -29,7 +34,7 @@ export class RecordsChunk {
       rows.map((r) => new FlatfileRecord(r)),
       {
         status,
-        skip: 0,
+        skip: skip,
         limit,
         totalRecords: totalRows,
         index: typeof index === 'number' ? index + 1 : undefined,


### PR DESCRIPTION
* the `totalRecords` param on `RecordChunk`s is misleading!
* `totalRecords` is actually the total remaining records (I don't think we can currently rename this however)
* the PR converts the logic to use the same skip every time and zero the final time but this might actually re-order row data
* Additionally, the `evaluate` event was potentially emitted multiple times, this had the effect of resetting the RecordChunkIterator, and thus the RecordChunk, leading customers to believe that the index was never correct