### PR TITLE
fix: remove targets from babel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@flatfile/sdk",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@flatfile/sdk",
-      "version": "2.2.2",
+      "version": "2.2.3",
       "license": "ISC",
       "dependencies": {
         "eventemitter3": "^4.0.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@flatfile/sdk",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@flatfile/sdk",
-      "version": "2.2.3",
+      "version": "2.2.4",
       "license": "ISC",
       "dependencies": {
         "eventemitter3": "^4.0.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@flatfile/sdk",
-  "version": "2.1.6",
+  "version": "2.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@flatfile/sdk",
-      "version": "2.1.6",
+      "version": "2.2.1",
       "license": "ISC",
       "dependencies": {
         "eventemitter3": "^4.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flatfile/sdk",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Flatfile SDK",
   "private": false,
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flatfile/sdk",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "Flatfile SDK",
   "private": false,
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flatfile/sdk",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "Flatfile SDK",
   "private": false,
   "repository": {

--- a/webpack.base.js
+++ b/webpack.base.js
@@ -36,6 +36,7 @@ module.exports = {
       {
         // Include ts, tsx, js, and jsx files.
         test: /\.(ts|js)x?$/,
+        exclude: /node_modules\/(?!graphql-subscriptions-client)/,
         use: {
           loader: 'babel-loader',
           options: {

--- a/webpack.base.js
+++ b/webpack.base.js
@@ -36,7 +36,6 @@ module.exports = {
       {
         // Include ts, tsx, js, and jsx files.
         test: /\.(ts|js)x?$/,
-        exclude: /node_modules/,
         use: {
           loader: 'babel-loader',
           options: {

--- a/webpack.base.js
+++ b/webpack.base.js
@@ -43,9 +43,6 @@ module.exports = {
             presets: [
               [
                 '@babel/preset-env',
-                {
-                  targets: "> 0.25%, not dead",
-                },
               ],
               [
                 '@babel/preset-react',


### PR DESCRIPTION
- forces babel to compile to ES5 
- now compiles `graphql-subscriptions-client `node module as well. This was the offending package resulting in the spread operator.

Not 100% sure of this fix but have:
- Checked compiled `index.js` file and the offending spread operator was no longer present.
- Ran `npx serve -s build ` and it still works
- Tested locally on demo env and confirmed fully functional

Hopefully fixes https://linear.app/flatfile/issue/SUP-591/[customer-meez]-portal-v3-error-with-package-bundle-when-importing-it.

 When no targets are specified: Babel will assume you are targeting the oldest browsers possible. [For example, @babel/preset-env will transform all ES2015-ES2020 code to be ES5 compatible.](https://babeljs.io/docs/en/options#no-targets)